### PR TITLE
2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,15 @@ Ansible role to deploy [Caddy](https://caddyserver.com/) in a Docker container.
 ## Role Variables
 
 ```yaml
-caddy_docker_config_directory: /etc/caddy/config/
-caddy_docker_data_directory: /etc/caddy/data/
+caddy_docker_config_directory:
+  path: ~/.config/caddy/
+  # Optional
+  # owner: owner
+  # group: group
+  # mode: 0755
+caddy_docker_data_directory:
+  path: ~/.local/share/caddy/
+  # ...
 ```
 
 Absolute path to Caddy config and data directories to be created. Attached to the container as bind mounts.
@@ -37,7 +44,9 @@ caddy_docker_caddyfile: |-
 Contents of the [Caddyfile](https://caddyserver.com/docs/caddyfile) used to configure Caddy.
 
 ```yaml
-caddy_docker_caddyfile_path: /etc/caddy/Caddyfile
+caddy_docker_caddyfile_file:
+  path: ~/.config/Caddyfile
+  # ...
 ```
 
 Absolute path to the Caddyfile to be created. Attached to the container as a bind mount.
@@ -52,7 +61,9 @@ caddy_docker_builder_image_tag: 2.6.1-builder
 Container image repositories, names and tags used to deploy Caddy as a container. The `caddy_docker_builder_*` variables are only used when `caddy_docker_plugins` is populated.
 
 ```yaml
-caddy_docker_builder_directory: /etc/caddy/builder/
+caddy_docker_builder_directory:
+  path: /tmp/caddy-builder/
+  # ...
 ```
 
 Absolute path for the directory used as the container build context. This variable is only used when `caddy_docker_plugins` is populated. You may want to override this variable if you bring your own dockerfile template and want to include files during the Caddy container's build process.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,16 +1,16 @@
 ---
 # defaults file for caddy_docker
-caddy_docker_config_directory: /etc/caddy/config/
-caddy_docker_data_directory: /etc/caddy/data/
+caddy_docker_config_directory: ~/.config/caddy/
+caddy_docker_data_directory: ~/.local/share/caddy/
 caddy_docker_caddyfile: |-
   localhost
   respond "Hello, world!"
-caddy_docker_caddyfile_path: /etc/caddy/Caddyfile
+caddy_docker_caddyfile_path: ~/.config/Caddyfile
 caddy_docker_image: caddy
 caddy_docker_image_tag: 2.6.1-alpine
 caddy_docker_builder_image: caddy
 caddy_docker_builder_image_tag: 2.6.1-builder
-caddy_docker_builder_directory: /etc/caddy/builder/
+caddy_docker_builder_directory: ~/.config/caddy-builder/
 caddy_docker_builder_template: dockerfile.j2
 caddy_docker_plugins: []
 caddy_docker_ingress_network: caddy

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,16 +1,20 @@
 ---
 # defaults file for caddy_docker
-caddy_docker_config_directory: ~/.config/caddy/
-caddy_docker_data_directory: ~/.local/share/caddy/
+caddy_docker_config_directory:
+  path: ~/.config/caddy/
+caddy_docker_data_directory:
+  path: ~/.local/share/caddy/
 caddy_docker_caddyfile: |-
   localhost
   respond "Hello, world!"
-caddy_docker_caddyfile_path: ~/.config/Caddyfile
+caddy_docker_caddyfile_file:
+  path: ~/.config/Caddyfile
 caddy_docker_image: caddy
 caddy_docker_image_tag: 2.6.1-alpine
 caddy_docker_builder_image: caddy
 caddy_docker_builder_image_tag: 2.6.1-builder
-caddy_docker_builder_directory: ~/.config/caddy-builder/
+caddy_docker_builder_directory:
+  path: /tmp/caddy-builder/
 caddy_docker_builder_template: dockerfile.j2
 caddy_docker_plugins: []
 caddy_docker_ingress_network: caddy

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,9 +10,9 @@ caddy_docker_caddyfile: |-
 caddy_docker_caddyfile_file:
   path: ~/.config/Caddyfile
 caddy_docker_image: caddy
-caddy_docker_image_tag: 2.6.1-alpine
+caddy_docker_image_tag: 2.6.2-alpine
 caddy_docker_builder_image: caddy
-caddy_docker_builder_image_tag: 2.6.1-builder
+caddy_docker_builder_image_tag: 2.6.2-builder
 caddy_docker_builder_directory:
   path: /tmp/caddy-builder/
 caddy_docker_builder_template: dockerfile.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,22 +1,24 @@
 ---
 # tasks file for caddy_docker
-- name: Create Caddy config directory
-  ansible.builtin.file:
-    path: "{{ caddy_docker_config_directory }}"
-    state: directory
-    mode: 0755
 
-- name: Create Caddy data directory
+- name: "Create Caddy directories {{ item.path }}"
   ansible.builtin.file:
-    path: "{{ caddy_docker_data_directory }}"
+    path: "{{ item.path }}"
     state: directory
-    mode: 0755
+    owner: "{{ item.owner | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
+    mode: "{{ item.mode | default(0700) }}"
+  with_items:
+    - "{{ caddy_docker_config_directory }}"
+    - "{{ caddy_docker_data_directory }}"
 
 - name: Create Caddyfile
   ansible.builtin.copy:
     content: "{{ caddy_docker_caddyfile }}"
-    dest: "{{ caddy_docker_caddyfile_path }}"
-    mode: 0755
+    dest: "{{ caddy_docker_caddyfile_file.path }}"
+    owner: "{{ caddy_docker_caddyfile_file.owner | default(omit) }}"
+    group: "{{ caddy_docker_caddyfile_file.group | default(omit) }}"
+    mode: "{{ caddy_docker_caddyfile_file.mode | default(0700) }}"
   notify: Reload Caddy configuration
 
 - name: Caddy with plugins
@@ -24,21 +26,23 @@
   block:
     - name: Create Caddy builder directory
       ansible.builtin.file:
-        path: "{{ caddy_docker_builder_directory }}"
+        path: "{{ caddy_docker_builder_directory.path }}"
         state: directory
-        mode: 0755
+        owner: "{{ caddy_docker_builder_directory.owner | default(omit) }}"
+        group: "{{ caddy_docker_builder_directory.group | default(omit) }}"
+        mode: "{{ caddy_docker_builder_directory.mode | default(0755) }}"
 
     - name: Create Caddy dockerfile from template
       ansible.builtin.template:
         src: "{{ caddy_docker_builder_template }}"
-        dest: "{{ caddy_docker_builder_directory }}/dockerfile"
+        dest: "{{ caddy_docker_builder_directory.path }}/dockerfile"
         mode: 0755
 
     - name: Build Caddy container image
       community.docker.docker_image:
         name: "caddy-custom:plugins"
         build:
-          path: "{{ caddy_docker_builder_directory }}"
+          path: "{{ caddy_docker_builder_directory.path }}"
           pull: true
         source: build
         state: present
@@ -58,11 +62,11 @@
   ansible.builtin.set_fact:
     caddy_docker_volumes:
       # Caddyfile
-      - "{{ caddy_docker_caddyfile_path }}:/etc/caddy/Caddyfile"
+      - "{{ caddy_docker_caddyfile_file.path }}:/etc/caddy/Caddyfile"
       # Caddy data
-      - "{{ caddy_docker_data_directory }}:/data"
+      - "{{ caddy_docker_data_directory.path }}:/data"
       # Caddy config
-      - "{{ caddy_docker_config_directory }}:/config"
+      - "{{ caddy_docker_config_directory.path }}:/config"
 
 - name: Add caddy_docker_extra_volumes
   ansible.builtin.set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     state: directory
     owner: "{{ item.owner | default(omit) }}"
     group: "{{ item.group | default(omit) }}"
-    mode: "{{ item.mode | default(0700) }}"
+    mode: "{{ item.mode | default('0700') }}"
   with_items:
     - "{{ caddy_docker_config_directory }}"
     - "{{ caddy_docker_data_directory }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for caddy_docker
 
-- name: "Create Caddy directories {{ item.path }}"
+- name: Create Caddy directories
   ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
     dest: "{{ caddy_docker_caddyfile_file.path }}"
     owner: "{{ caddy_docker_caddyfile_file.owner | default(omit) }}"
     group: "{{ caddy_docker_caddyfile_file.group | default(omit) }}"
-    mode: "{{ caddy_docker_caddyfile_file.mode | default(0700) }}"
+    mode: "{{ caddy_docker_caddyfile_file.mode | default('0700') }}"
   notify: Reload Caddy configuration
 
 - name: Caddy with plugins
@@ -30,7 +30,7 @@
         state: directory
         owner: "{{ caddy_docker_builder_directory.owner | default(omit) }}"
         group: "{{ caddy_docker_builder_directory.group | default(omit) }}"
-        mode: "{{ caddy_docker_builder_directory.mode | default(0755) }}"
+        mode: "{{ caddy_docker_builder_directory.mode | default('0755') }}"
 
     - name: Create Caddy dockerfile from template
       ansible.builtin.template:


### PR DESCRIPTION
# 2.0.0

## Changes

Allow `caddy_docker_config_directory`, `caddy_docker_data_directory`, `caddy_docker_caddyfile_file` and `caddy_docker_builder_directory` to be truly configurable.

Users can now modify the `owner`, `group` and `mode` which will be passed directly to `ansible.builtin.file`.

The defaults have been modified slightly to reflected conventions in [Caddy conventions](https://caddyserver.com/docs/conventions#file-locations). Furthermore, these directories are created with default permission (0700) outlined in the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

Bump image tags to `2.6.2-*`