### PR TITLE
3.0.0

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -1,5 +1,5 @@
 name: Molecule
-on: [push, pull_request]
+on: [pull_request]
 
 defaults:
   run:
@@ -15,3 +15,4 @@ jobs:
       - uses: gofrolist/molecule-action@v2
         with:
           molecule_working_dir: dbrennand.caddy_docker
+          molecule_args: --all

--- a/README.md
+++ b/README.md
@@ -52,13 +52,11 @@ caddy_docker_caddyfile_file:
 Absolute path to the Caddyfile to be created. Attached to the container as a bind mount.
 
 ```yaml
-caddy_docker_image: caddy
-caddy_docker_image_tag: 2.6.1-alpine
-caddy_docker_builder_image: caddy
-caddy_docker_builder_image_tag: 2.6.1-builder
+caddy_docker_image: caddy:2.6.2-alpine
+caddy_docker_builder_image: caddy:2.6.2-builder
 ```
 
-Container image repositories, names and tags used to deploy Caddy as a container. The `caddy_docker_builder_*` variables are only used when `caddy_docker_plugins` is populated.
+Container image repositories, names and tags used to deploy Caddy as a container. The `caddy_docker_builder_image` variable is only used when `caddy_docker_plugins` is populated.
 
 ```yaml
 caddy_docker_builder_directory:

--- a/README.md
+++ b/README.md
@@ -85,10 +85,11 @@ caddy_docker_plugins: []
 List of plugins to include in the Caddy container.
 
 ```yaml
-caddy_docker_ingress_network: caddy
+caddy_docker_networks:
+  - name: caddy
 ```
 
-Name of the ingress Docker network to be created and attached to the Caddy container.
+Names of the Docker networks to be created and attached to the Caddy container.
 
 ```yaml
 caddy_docker_command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
@@ -141,6 +142,14 @@ caddy_docker_environment_variables: {}
 ```
 
 Environment variables to apply to the Caddy container.
+
+### Optional
+
+```yaml
+caddy_docker_network_mode: host
+```
+
+Docker network mode to use for the Caddy container. The `caddy_docker_networks`, `caddy_docker_ports` and `caddy_docker_exposed_ports` variables have no affect when this variable is set to `host`.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ caddy_docker_networks:
 Names of the Docker networks to be created and attached to the Caddy container.
 
 ```yaml
+caddy_docker_network_mode: default
+```
+
+Docker network mode to use for the Caddy container. The `caddy_docker_networks`, `caddy_docker_ports` and `caddy_docker_exposed_ports` variables have no affect when this variable is set to `host`.
+
+```yaml
 caddy_docker_command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
 ```
 
@@ -142,14 +148,6 @@ caddy_docker_environment_variables: {}
 ```
 
 Environment variables to apply to the Caddy container.
-
-### Optional
-
-```yaml
-caddy_docker_network_mode: host
-```
-
-Docker network mode to use for the Caddy container. The `caddy_docker_networks`, `caddy_docker_ports` and `caddy_docker_exposed_ports` variables have no affect when this variable is set to `host`.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,10 +9,8 @@ caddy_docker_caddyfile: |-
   respond "Hello, world!"
 caddy_docker_caddyfile_file:
   path: ~/.config/Caddyfile
-caddy_docker_image: caddy
-caddy_docker_image_tag: 2.6.2-alpine
-caddy_docker_builder_image: caddy
-caddy_docker_builder_image_tag: 2.6.2-builder
+caddy_docker_image: caddy:2.6.2-alpine
+caddy_docker_builder_image: caddy:2.6.2-builder
 caddy_docker_builder_directory:
   path: /tmp/caddy-builder/
 caddy_docker_builder_template: dockerfile.j2

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,8 @@ caddy_docker_builder_directory:
   path: /tmp/caddy-builder/
 caddy_docker_builder_template: dockerfile.j2
 caddy_docker_plugins: []
-caddy_docker_ingress_network: caddy
+caddy_docker_networks:
+  - name: caddy
 caddy_docker_command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
 caddy_docker_restart_policy: unless-stopped
 caddy_docker_ports:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,7 @@ caddy_docker_builder_template: dockerfile.j2
 caddy_docker_plugins: []
 caddy_docker_networks:
   - name: caddy
+caddy_docker_network_mode: default
 caddy_docker_command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
 caddy_docker_restart_policy: unless-stopped
 caddy_docker_ports:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -9,6 +9,7 @@
     caddy_docker_plugins:
       - github.com/lucaslorentz/caddy-docker-proxy/plugin
       - github.com/caddy-dns/cloudflare
+    caddy_docker_network_mode: host
   pre_tasks:
     - name: Update apt cache
       ansible.builtin.apt:

--- a/molecule/network_mode/converge.yml
+++ b/molecule/network_mode/converge.yml
@@ -6,6 +6,7 @@
       - name: docker
     docker_daemon_options:
       storage-driver: "vfs"
+    caddy_docker_network_mode: host
   pre_tasks:
     - name: Update apt cache
       ansible.builtin.apt:

--- a/molecule/network_mode/molecule.yml
+++ b/molecule/network_mode/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-debian10-ansible:latest
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/network_mode/verify.yml
+++ b/molecule/network_mode/verify.yml
@@ -15,5 +15,5 @@
       community.docker.docker_network_info:
         name: "{{ item.name }}"
       with_items: "{{ caddy_docker_networks }}"
-      register: network_result
-      failed_when: network_result.exists
+      register: network
+      failed_when: network.exists

--- a/molecule/network_mode/verify.yml
+++ b/molecule/network_mode/verify.yml
@@ -10,10 +10,3 @@
         validate_certs: false
       register: caddy_resp
       failed_when: "'Hello, world!' not in caddy_resp.content"
-
-    - name: Verify Caddy Docker networks do not exist
-      community.docker.docker_network_info:
-        name: "{{ item.name }}"
-      with_items: "{{ caddy_docker_networks }}"
-      register: network
-      failed_when: network.exists

--- a/molecule/network_mode/verify.yml
+++ b/molecule/network_mode/verify.yml
@@ -1,0 +1,19 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Verify Caddy is responding on localhost
+      ansible.builtin.uri:
+        url: http://localhost
+        return_content: true
+        validate_certs: false
+      register: caddy_resp
+      failed_when: "'Hello, world!' not in caddy_resp.content"
+
+    - name: Verify Caddy Docker networks do not exist
+      community.docker.docker_network_info:
+        name: "{{ item.name }}"
+      with_items: "{{ caddy_docker_networks }}"
+      register: network_result
+      failed_when: network_result.exists

--- a/molecule/network_mode/verify.yml
+++ b/molecule/network_mode/verify.yml
@@ -10,3 +10,11 @@
         validate_certs: false
       register: caddy_resp
       failed_when: "'Hello, world!' not in caddy_resp.content"
+
+    - name: Verify Caddy Docker networks do not exist
+      community.docker.docker_network_info:
+        name: "{{ item }}"
+      with_items:
+        - caddy
+      register: network
+      failed_when: network.exists

--- a/molecule/plugins/converge.yml
+++ b/molecule/plugins/converge.yml
@@ -6,6 +6,9 @@
       - name: docker
     docker_daemon_options:
       storage-driver: "vfs"
+    caddy_docker_plugins:
+      - github.com/lucaslorentz/caddy-docker-proxy/plugin
+      - github.com/caddy-dns/cloudflare
   pre_tasks:
     - name: Update apt cache
       ansible.builtin.apt:

--- a/molecule/plugins/molecule.yml
+++ b/molecule/plugins/molecule.yml
@@ -1,0 +1,17 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: instance
+    image: geerlingguy/docker-debian10-ansible:latest
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/plugins/verify.yml
+++ b/molecule/plugins/verify.yml
@@ -1,0 +1,12 @@
+---
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Verify Caddy is responding on localhost
+      ansible.builtin.uri:
+        url: http://localhost
+        return_content: true
+        validate_certs: false
+      register: caddy_resp
+      failed_when: "'Hello, world!' not in caddy_resp.content"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,6 +80,7 @@
     restart_policy: "{{ caddy_docker_restart_policy }}"
     networks:
       - name: "{{ caddy_docker_ingress_network }}"
+    network_mode: "{{ caddy_docker_network_mode | default(omit) }}"
     ports: "{{ caddy_docker_ports }}"
     exposed_ports: "{{ caddy_docker_exposed_ports }}"
     etc_hosts: "{{ caddy_docker_etc_hosts }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,7 +80,7 @@
     image: "{{ caddy_docker_image }}"
     command: "{{ caddy_docker_command }}"
     restart_policy: "{{ caddy_docker_restart_policy }}"
-    network_mode: "{{ caddy_docker_network_mode | default('default') }}"
+    network_mode: "{{ caddy_docker_network_mode | default('default', True) }}"
     networks: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_networks }}"
     ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_ports }}"
     exposed_ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_exposed_ports }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,6 +53,7 @@
         caddy_docker_image: caddy-custom:plugins
 
 - name: Create Caddy Docker ingress network
+  when: caddy_docker_network_mode != "host"
   community.docker.docker_network:
     name: "{{ caddy_docker_ingress_network }}"
     state: present
@@ -78,11 +79,11 @@
     image: "{{ caddy_docker_image }}"
     command: "{{ caddy_docker_command }}"
     restart_policy: "{{ caddy_docker_restart_policy }}"
-    networks:
-      - name: "{{ caddy_docker_ingress_network }}"
     network_mode: "{{ caddy_docker_network_mode | default(omit) }}"
-    ports: "{{ caddy_docker_ports }}"
-    exposed_ports: "{{ caddy_docker_exposed_ports }}"
+    networks:
+      - name: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_ingress_network }}"
+    ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_ports }}"
+    exposed_ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_exposed_ports }}"
     etc_hosts: "{{ caddy_docker_etc_hosts }}"
     volumes: "{{ caddy_docker_volumes }}"
     env: "{{ caddy_docker_environment_variables }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,7 @@
     name: "{{ item.name }}"
     state: present
   with_items: "{{ caddy_docker_networks }}"
-  when: caddy_docker_network_mode is not defined or caddy_docker_network_mode != "host"
+  when: caddy_docker_network_mode != "host"
 
 - name: Set caddy_docker_volumes
   ansible.builtin.set_fact:
@@ -80,7 +80,7 @@
     image: "{{ caddy_docker_image }}"
     command: "{{ caddy_docker_command }}"
     restart_policy: "{{ caddy_docker_restart_policy }}"
-    network_mode: "{{ omit if caddy_docker_network_mode is not defined else caddy_docker_network_mode }}"
+    network_mode: "{{ caddy_docker_network_mode }}"
     networks: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_networks }}"
     ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_ports }}"
     exposed_ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_exposed_ports }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,11 +52,12 @@
       ansible.builtin.set_fact:
         caddy_docker_image: caddy-custom:plugins
 
-- name: Create Caddy Docker ingress network
+- name: Create Caddy Docker network(s)
   when: caddy_docker_network_mode != "host"
   community.docker.docker_network:
-    name: "{{ caddy_docker_ingress_network }}"
+    name: "{{ item.name }}"
     state: present
+  with_items: "{{ caddy_docker_network }}"
 
 - name: Set caddy_docker_volumes
   ansible.builtin.set_fact:
@@ -80,8 +81,7 @@
     command: "{{ caddy_docker_command }}"
     restart_policy: "{{ caddy_docker_restart_policy }}"
     network_mode: "{{ caddy_docker_network_mode | default(omit) }}"
-    networks:
-      - name: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_ingress_network }}"
+    networks: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_network }}"
     ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_ports }}"
     exposed_ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_exposed_ports }}"
     etc_hosts: "{{ caddy_docker_etc_hosts }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,11 +53,11 @@
         caddy_docker_image: caddy-custom:plugins
 
 - name: Create Caddy Docker network(s)
-  when: caddy_docker_network_mode != "host"
   community.docker.docker_network:
     name: "{{ item.name }}"
     state: present
-  with_items: "{{ caddy_docker_network }}"
+  with_items: "{{ caddy_docker_networks }}"
+  when: caddy_docker_network_mode != "host"
 
 - name: Set caddy_docker_volumes
   ansible.builtin.set_fact:
@@ -81,7 +81,7 @@
     command: "{{ caddy_docker_command }}"
     restart_policy: "{{ caddy_docker_restart_policy }}"
     network_mode: "{{ caddy_docker_network_mode | default(omit) }}"
-    networks: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_network }}"
+    networks: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_networks }}"
     ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_ports }}"
     exposed_ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_exposed_ports }}"
     etc_hosts: "{{ caddy_docker_etc_hosts }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,7 +80,7 @@
     image: "{{ caddy_docker_image }}"
     command: "{{ caddy_docker_command }}"
     restart_policy: "{{ caddy_docker_restart_policy }}"
-    network_mode: "{{ caddy_docker_network_mode | default(omit) }}"
+    network_mode: "{{ caddy_docker_network_mode | default('default') }}"
     networks: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_networks }}"
     ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_ports }}"
     exposed_ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_exposed_ports }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,10 +48,9 @@
         state: present
         debug: true
 
-    - name: Override caddy_docker_image and caddy_docker_image_tag
+    - name: Override caddy_docker_image
       ansible.builtin.set_fact:
-        caddy_docker_image: caddy-custom
-        caddy_docker_image_tag: plugins
+        caddy_docker_image: caddy-custom:plugins
 
 - name: Create Caddy Docker ingress network
   community.docker.docker_network:
@@ -76,7 +75,7 @@
 - name: Create Caddy Docker container
   community.docker.docker_container:
     name: caddy
-    image: "{{ caddy_docker_image }}:{{ caddy_docker_image_tag }}"
+    image: "{{ caddy_docker_image }}"
     command: "{{ caddy_docker_command }}"
     restart_policy: "{{ caddy_docker_restart_policy }}"
     networks:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
     dest: "{{ caddy_docker_caddyfile_file.path }}"
     owner: "{{ caddy_docker_caddyfile_file.owner | default(omit) }}"
     group: "{{ caddy_docker_caddyfile_file.group | default(omit) }}"
-    mode: "{{ caddy_docker_caddyfile_file.mode | default('0700') }}"
+    mode: "{{ caddy_docker_caddyfile_file.mode | default('0600') }}"
   notify: Reload Caddy configuration
 
 - name: Caddy with plugins

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,7 +36,7 @@
       ansible.builtin.template:
         src: "{{ caddy_docker_builder_template }}"
         dest: "{{ caddy_docker_builder_directory.path }}/dockerfile"
-        mode: 0755
+        mode: 0655
 
     - name: Build Caddy container image
       community.docker.docker_image:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -80,7 +80,7 @@
     image: "{{ caddy_docker_image }}"
     command: "{{ caddy_docker_command }}"
     restart_policy: "{{ caddy_docker_restart_policy }}"
-    network_mode: "{{ caddy_docker_network_mode | default('default', True) }}"
+    network_mode: "{{ omit if caddy_docker_network_mode is not defined else caddy_docker_network_mode }}"
     networks: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_networks }}"
     ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_ports }}"
     exposed_ports: "{{ omit if caddy_docker_network_mode == 'host' else caddy_docker_exposed_ports }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,7 +57,7 @@
     name: "{{ item.name }}"
     state: present
   with_items: "{{ caddy_docker_networks }}"
-  when: caddy_docker_network_mode != "host"
+  when: caddy_docker_network_mode is not defined or caddy_docker_network_mode != "host"
 
 - name: Set caddy_docker_volumes
   ansible.builtin.set_fact:

--- a/templates/dockerfile.j2
+++ b/templates/dockerfile.j2
@@ -1,10 +1,10 @@
-FROM {{ caddy_docker_builder_image }}:{{ caddy_docker_builder_image_tag }} AS builder
+FROM {{ caddy_docker_builder_image }} AS builder
 
 RUN xcaddy build \
     {% for plugin in caddy_docker_plugins %}
     --with {{ plugin }} {{ "\\" if not loop.last }}
     {% endfor %}
 
-FROM {{ caddy_docker_image }}:{{ caddy_docker_image_tag }}
+FROM {{ caddy_docker_image }}
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy


### PR DESCRIPTION
# 3.0.0 - Changes

Removed `caddy_docker_image_tag` and `caddy_docker_builder_image_tag` for simplicity. There is now only `caddy_docker_image` and `caddy_docker_builder_image` which the repository, image name and tag can be provided.

Modified `mode` permission on the Caddyfile and docker template as execute is not necessary.

Added separate molecule test scenarios.

Modify `caddy_docker_ingress_network` to `caddy_docker_networks`. New usage:

```yaml
caddy_docker_networks:
  - name: caddy
```

Added new variable `caddy_docker_network_mode` to specify the network mode for the container.